### PR TITLE
Fix a bug where some messages could be delayed

### DIFF
--- a/Assets/Scripts/Message.cs
+++ b/Assets/Scripts/Message.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine;
 
 public struct Message 
 {

--- a/Assets/Scripts/Message.cs
+++ b/Assets/Scripts/Message.cs
@@ -52,6 +52,11 @@ public struct Message
 
         return serializedMessage;
     }
-    
+
+    public override string ToString()
+    {
+        return $"Message({type}, len={data.Length})";
+    }
+
     public static Span<byte> GetSignature() => new byte[5] {1, 2, 3, 4, 5};
 }

--- a/Assets/Scripts/Message.cs
+++ b/Assets/Scripts/Message.cs
@@ -59,4 +59,27 @@ public struct Message
     }
 
     public static Span<byte> GetSignature() => new byte[5] {1, 2, 3, 4, 5};
+
+    public static (int msgLen, Message message)? ReadMessage(ReadOnlySpan<byte> buffer)
+    {
+        int headerLength = 5 + 2 + 1; 
+        if (buffer.Length < headerLength)
+            return null;
+
+        var signatureSpan = buffer.Slice(0, 5);
+        if (!signatureSpan.SequenceEqual(GetSignature()))
+            throw new ArgumentException("Invalid message signature!");
+
+        var payloadLenSpan = buffer.Slice(5, 2);
+        ushort payloadLength = BitConverter.ToUInt16(payloadLenSpan.ToArray(), 0);
+        var messageType = (MessageType)buffer[7];
+
+        var totalLength = headerLength + payloadLength;
+        if (totalLength < buffer.Length)
+            return null;
+
+        var payload = buffer.Slice(headerLength, payloadLength).ToArray();
+
+        return (totalLength, new Message(messageType, payload));
+    }
 }

--- a/Assets/Scripts/Message.cs
+++ b/Assets/Scripts/Message.cs
@@ -32,7 +32,7 @@ public struct Message
     {
         this.signature = GetSignature().ToArray();
         this.type = type;
-        this.data = new byte[0];
+        this.data = Array.Empty<byte>();
         this.length = (ushort)0;
     }
 

--- a/Assets/Scripts/Networker.cs
+++ b/Assets/Scripts/Networker.cs
@@ -62,9 +62,8 @@ public class Networker : MonoBehaviour
         // To track latency, every pingDelay seconds we ping the socket, we expect back a pong in a timely fashion
         if(Time.timeSinceLevelLoad >= pingAtTime && stream != null && pongReceived)
         {
-            byte[] ping = new Message(MessageType.Ping).Serialize();
             try {
-                stream.Write(ping, 0, ping.Length);
+                SendMessage(new Message(MessageType.Ping));
                 pingedAtTime = Time.timeSinceLevelLoad;
                 pingAtTime = Time.timeSinceLevelLoad + pingDelay;
                 pongReceived = false;
@@ -92,9 +91,8 @@ public class Networker : MonoBehaviour
         else if(client != null && client.Connected)
         {
             // Write disconnect to socket
-            byte[] disconnectMessage = new Message(MessageType.Disconnect).Serialize();
             try {
-                stream.Write(disconnectMessage, 0, disconnectMessage.Length);
+                SendMessage(new Message(MessageType.Disconnect));
             } catch (Exception e) {
                 Debug.LogWarning($"Failed to write to socket with error:\n{e}");
             }
@@ -254,8 +252,15 @@ public class Networker : MonoBehaviour
     // Both client + server
     public void SendMessage(Message message)
     {
-        byte[] messageData = message.Serialize();
-        stream?.Write(messageData, 0, messageData.Length);
+        if (stream != null)
+        {
+            byte[] messageData = message.Serialize();
+            stream.Write(messageData, 0, messageData.Length);
+        }
+        else
+        {
+            Debug.LogWarning($"No stream, cannot send message: {message}");
+        }
     }
     
     private void ReceiveMessage(IAsyncResult ar)
@@ -399,9 +404,8 @@ public class Networker : MonoBehaviour
     private void ReceivePing()
     {
         // All pings should get a pong in response
-        byte[] pong = new Message(MessageType.Pong).Serialize();
         try {
-            stream.Write(pong, 0, pong.Length);
+            SendMessage(new Message(MessageType.Pong));
         } catch (Exception e) {
             Debug.LogWarning($"Failed to write to socket with error:\n{e}");
         }
@@ -492,9 +496,8 @@ public class Networker : MonoBehaviour
         if(client == null)
             return;
 
-        byte[] ProposeTeamChangeMessage = new Message(MessageType.ProposeTeamChange).Serialize();
         try {
-            stream.Write(ProposeTeamChangeMessage, 0, ProposeTeamChangeMessage.Length);
+            SendMessage(new Message(MessageType.ProposeTeamChange));
         } catch (Exception e) {
             Debug.LogWarning($"Failed to write to socket with error:\n{e}");
         }
@@ -523,9 +526,8 @@ public class Networker : MonoBehaviour
         if(lobby == null)
             return;
 
-        byte[] response = new Message(answer).Serialize();
         try {
-            stream.Write(response, 0, response.Length);
+            SendMessage(new Message(answer));
         } catch (Exception e) {
             Debug.LogWarning($"Failed to write to socket with error:\n{e}");
         }
@@ -639,13 +641,13 @@ public class Networker : MonoBehaviour
         if(answer == MessageType.AcceptDraw)
             multiplayer.Draw(timestamp);
 
-        byte[] response = new Message(
-            answer, 
+        Message response = new Message(
+            answer,
             Encoding.ASCII.GetBytes(JsonConvert.SerializeObject(timestamp))
-        ).Serialize();
+        );
 
         try {
-            stream.Write(response, 0, response.Length);
+            SendMessage(response);
         } catch (Exception e) {
             Debug.LogWarning($"Failed to write to socket with error:\n{e}");
         }


### PR DESCRIPTION
When two messages are received within a small time window, they will be
put in one byte[]. The previous `CheckCompleteMessage` implementation only
handled the first message when bytes came in from the network. Now, all
messages will be handled.

This new implementation also avoids several allocations, and moves
message parsing code into the `Message` class where it belongs.

Edit: I would really recommend playtesting this before merging, as I have limited capabilities without blender installed on my machine.