### PR TITLE
double connect fix

### DIFF
--- a/Assets/Scripts/Networker.cs
+++ b/Assets/Scripts/Networker.cs
@@ -186,15 +186,26 @@ public class Networker : MonoBehaviour
     private void AcceptClientCallback(IAsyncResult ar)
     {
         try{
-            TcpClient incommingClient = server.EndAcceptTcpClient(ar);
+            TcpClient incomingClient = server.EndAcceptTcpClient(ar);
             if(client == null)
             {
-                client = incommingClient;
+                client = incomingClient;
                 stream = client.GetStream();
             }
             // In chess, there is only ever 2 players, (1 host, 1 player), so reject any connection trying to come in if the player slot is already full
             else
-                incommingClient.Close();
+            {
+                incomingClient.Close();
+                try
+                {
+                    server.BeginAcceptTcpClient(new AsyncCallback(AcceptClientCallback), server);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning($"Failed to connect to incoming client:\n{e}");
+                }
+                return;
+            }
         } catch (Exception e) {
             Debug.LogWarning($"Failed to connect to incoming client:\n{e}");
             return;

--- a/Assets/Scripts/Networker.cs
+++ b/Assets/Scripts/Networker.cs
@@ -488,6 +488,7 @@ public class Networker : MonoBehaviour
             lobby.RemovePlayer(player.Value);
             player = null;
             client = null;
+            stream = null;
 
             if(host.team == Team.Black)
             {


### PR DESCRIPTION
When a new connection was made to a full host, the new connection was
closed but the rest of the connect code still ran. This resulted in a
strange looking lobby and an "invalid signature" error.

Now, the new connection is closed and properly ignored.

This should fix the 3 players in one game issue as seen in discord.