### PR TITLE
Use unity api for copying IP

### DIFF
--- a/Assets/Scripts/UI/Buttons/CopyIPButton.cs
+++ b/Assets/Scripts/UI/Buttons/CopyIPButton.cs
@@ -1,8 +1,7 @@
-using System.Windows.Forms;
 using UnityEngine;
 
 public class CopyIPButton : MonoBehaviour
 {
     [SerializeField] private UnityEngine.UI.Button button;
-    private void Awake() => button.onClick.AddListener(() => Clipboard.SetText(Networker.GetPublicIPAddress()));
+    private void Awake() => button.onClick.AddListener(() => GUIUtility.systemCopyBuffer = Networker.GetPublicIPAddress());
 }


### PR DESCRIPTION
Building on mac fails because System.Windows.Forms is not available.
Using the systemCopyBuffer api allows the build to build again on mac.